### PR TITLE
skip VmFlags field when reading /proc/<pid>/smaps

### DIFF
--- a/process_linux.go
+++ b/process_linux.go
@@ -200,6 +200,9 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 		m.Path = first_line[len(first_line)-1]
 
 		for _, line := range block {
+			if strings.Contains(line, "VmFlags") {
+				continue
+			}
 			field := strings.Split(line, ":")
 			if len(field) < 2 {
 				continue


### PR DESCRIPTION
``` text
00400000-0040e000 r-xp 00000000 fd:09 297                                /bin/cat
Size:                 56 kB
Rss:                  56 kB
Pss:                  56 kB
Shared_Clean:          0 kB
Shared_Dirty:          0 kB
Private_Clean:        56 kB
Private_Dirty:         0 kB
Referenced:           56 kB
Anonymous:             0 kB
AnonHugePages:         0 kB
Swap:                  0 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Locked:                0 kB
VmFlags: rd ex mr mw me dw
```
